### PR TITLE
Add `overflow: hidden` on thumbnails to improve mobile.

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -118,8 +118,11 @@ body {
     color: white;
     text-decoration: none;
 }
-.rel more {
+.rel more { 
     font-size: 10px;
+}
+.rel_img { /* Prevent thumbnail from increasing width on mobile. */
+    overflow: hidden;
 }
 #sbox {
     width: 100%;

--- a/static/style.css
+++ b/static/style.css
@@ -118,7 +118,7 @@ body {
     color: white;
     text-decoration: none;
 }
-.rel more { 
+.rel more {
     font-size: 10px;
 }
 .rel_img { /* Prevent thumbnail from increasing width on mobile. */

--- a/static/style.css
+++ b/static/style.css
@@ -121,7 +121,7 @@ body {
 .rel more {
     font-size: 10px;
 }
-.rel_img { /* Prevent thumbnail from increasing width on mobile. */
+.rel_img { /* Prevent thumbnail from increasing width (useful on mobile). */
     overflow: hidden;
 }
 #sbox {


### PR DESCRIPTION
Before:

![image](https://github.com/karpathy/arxiv-sanity-lite/assets/8830910/4739f43b-f5e9-4999-94a1-fe0f467583d0)

After:

![image](https://github.com/karpathy/arxiv-sanity-lite/assets/8830910/ff7410bb-fdde-4908-b5c5-3fe2a6d6c059)

